### PR TITLE
Add shebang line

### DIFF
--- a/scaladiagrams
+++ b/scaladiagrams
@@ -1,1 +1,2 @@
+#!/bin/sh
 java -jar `dirname $0`/target/scala-2.11/scaladiagrams-assembly-1.0.jar "$@"


### PR DESCRIPTION
Removes the following error when executing in a fish shell: 

```sh
Failed to execute process './scaladiagrams'. Reason:
exec: Exec format error
The file './scaladiagrams' is marked as an executable but could not be run by the operating system.
```
