### PR TITLE
Build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ such as [GraphViz](http://www.graphviz.org/) to draw the hierarchy.
 
 Usage
 -----
-First, compile and package with ./build 
+First, inside this project, run the `build` executable file with command `./build`.
 
 To run Scaladiagrams do the following:
 

--- a/build
+++ b/build
@@ -1,1 +1,3 @@
-`dirname $0`/sbt assembly
+#!/bin/bash
+
+sbt clean assembly

--- a/scaladiagrams
+++ b/scaladiagrams
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 java -jar `dirname $0`/target/scala-2.11/scaladiagrams-assembly-1.0.jar "$@"


### PR DESCRIPTION
**`build`**
I added a shebang line to `build` to make it more resilient.  

In `build`, I dropped `directory $0` because is not 100% foolproof and the only thing lost by dropping it is that users need to run a command that only needs to be run once, `./build`, inside the project directory. There is [no simple, easy solution](https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel) that works 100% of the time. 

I also included the sbt `clean` command before assembly just to be extra safe.  

**`scaladiagrams`**  
I replaced `#!/bin/sh` with `#!/bin/bash` because `sh` is just symbolically linked to the default shell which can be anything: `zsh`, `bash`, `dash`, etc. 
